### PR TITLE
Buffer.GetData() GLES fix

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         (IntPtr)(offset.ToInt64() + element.Offset));
 
                     // only set the divisor if instancing is supported
-                    if (GraphicsCapabilities.SupportsInstancing) 
+                    if (GraphicsCapabilities.SupportsInstancing)
                         GL.VertexAttribDivisor(element.AttributeLocation, vertexBufferBinding.InstanceFrequency);
 
                     GraphicsExtensions.CheckGLError();
@@ -348,7 +348,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // Ensure the vertex attributes are reset
             _enabledVertexAttributes.Clear();
 
-            // Free all the cached shader programs. 
+            // Free all the cached shader programs.
             _programCache.Clear();
             _shaderProgram = null;
 
@@ -363,7 +363,7 @@ namespace Microsoft.Xna.Framework.Graphics
             for (int i = 0; i < _bufferBindingInfos.Length; i++)
                 _bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0, -1);
         }
-        
+
         private DepthStencilState clearDepthStencilState = new DepthStencilState { StencilEnable = true };
 
         private void PlatformClear(ClearOptions options, Vector4 color, float depth, int stencil)
@@ -386,7 +386,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		    var prevDepthStencilState = DepthStencilState;
             var prevBlendState = BlendState;
             ScissorRectangle = _viewport.Bounds;
-            // DepthStencilState.Default has the Stencil Test disabled; 
+            // DepthStencilState.Default has the Stencil Test disabled;
             // make sure stencil test is enabled before we clear since
             // some drivers won't clear with stencil test disabled
             DepthStencilState = this.clearDepthStencilState;
@@ -415,7 +415,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 bufferMask = bufferMask | ClearBufferMask.StencilBufferBit;
 			}
 
-			if ((options & ClearOptions.DepthBuffer) == ClearOptions.DepthBuffer) 
+			if ((options & ClearOptions.DepthBuffer) == ClearOptions.DepthBuffer)
             {
                 if (depth != _lastClearDepth)
                 {
@@ -435,7 +435,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if MONOMAC || IOS
             }
 #endif
-           		
+
             // Restore the previous render state.
 		    ScissorRectangle = prevScissorRect;
 		    DepthStencilState = prevDepthStencilState;
@@ -572,7 +572,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             GL.DepthRange(value.MinDepth, value.MaxDepth);
             GraphicsExtensions.LogGLError("GraphicsDevice.Viewport_set() GL.DepthRange");
-                
+
             // In OpenGL we have to re-apply the special "posFixup"
             // vertex shader uniform if the viewport changes.
             _vertexShaderDirty = true;
@@ -644,12 +644,14 @@ namespace Microsoft.Xna.Framework.Graphics
         // FBO cache used to resolve MSAA rendertargets, we create 1 FBO per RenderTargetBinding combination
         private Dictionary<RenderTargetBinding[], int> glResolveFramebuffers = new Dictionary<RenderTargetBinding[], int>(new RenderTargetBindingArrayComparer());
 
+        private bool _vaoCreated;
+
         internal void PlatformCreateRenderTarget(IRenderTarget renderTarget, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
             var color = 0;
             var depth = 0;
             var stencil = 0;
-            
+
             if (preferredMultiSampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
             {
                 this.framebufferHelper.GenRenderbuffer(out color);
@@ -663,7 +665,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var stencilInternalFormat = (RenderbufferStorage)0;
                 switch (preferredDepthFormat)
                 {
-                    case DepthFormat.Depth16: 
+                    case DepthFormat.Depth16:
                         depthInternalFormat = RenderbufferStorage.DepthComponent16;
                         break;
 #if GLES
@@ -947,7 +949,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Activates the Current Vertex/Pixel shader pair into a program.         
+        /// Activates the Current Vertex/Pixel shader pair into a program.
         /// </summary>
         private unsafe void ActivateShaderProgram()
         {
@@ -1129,7 +1131,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _geometryConstantBuffers.SetConstantBuffers(this, _shaderProgram);
                 GeometryShaderResources.PlatformApplyAllResourcesToDevice(this, _shaderProgram);
                 GeometrySamplerStates.PlatformSetSamplers(this, _geometryShader, GeometryShaderResources);
-            }      
+            }
         }
 
         private void PlatformDrawIndexedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount)
@@ -1198,7 +1200,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformDrawPrimitives(PrimitiveType primitiveType, int vertexStart, int vertexCount)
         {
-            ApplyState(true);   
+            ApplyState(true);
 
             ApplyAttribs(_vertexShader, 0);
 
@@ -1348,7 +1350,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             GraphicsExtensions.CheckGLError();
         }
-        
+
         private void PlatformDrawInstancedPrimitivesIndirect(PrimitiveType primitiveType, IndirectDrawBuffer indirectDrawBuffer, int alignedByteOffsetForArgs)
         {
             if (!GraphicsCapabilities.SupportsInstancing)
@@ -1357,6 +1359,13 @@ namespace Microsoft.Xna.Framework.Graphics
             ApplyState(true);
 
             ApplyAttribs(_vertexShader, 0);
+
+            if (!_vaoCreated) {
+                UIntPtr vao =  new UIntPtr(4);
+                  GL.GenVertexArrays(1, vao);
+                //GL.BindVertexArray(vao);
+                _vaoCreated = true;
+            }
 
             // Set vertex count for tesselation patch
             var primitiveTypeGL = PrimitiveTypeGL(primitiveType);
@@ -1413,7 +1422,7 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.CheckGLError();
 
             // The memory barrier will ensure that data written by the compute shader will be visible when other shaders read that data later.
-            // Better performance can probably be achievable by using only the required bits, and only when it's actually neccessary. 
+            // Better performance can probably be achievable by using only the required bits, and only when it's actually neccessary.
             GL.MemoryBarrier(MemoryBarrierBits.All);
             GraphicsExtensions.CheckGLError();
         }
@@ -1429,7 +1438,7 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.CheckGLError();
 
             // The memory barrier will ensure that data written by the compute shader will be visible when other shaders read that data later.
-            // Better performance can probably be achievable by using only the required bits, and only when it's actually neccessary. 
+            // Better performance can probably be achievable by using only the required bits, and only when it's actually neccessary.
             GL.MemoryBarrier(MemoryBarrierBits.All);
             GraphicsExtensions.CheckGLError();
         }
@@ -1510,7 +1519,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return new Rectangle(x, y, width, height);
         }
-        
+
         internal void PlatformSetMultiSamplingToMaximum(PresentationParameters presentationParameters, out int quality)
         {
             presentationParameters.MultiSampleCount = 4;
@@ -1569,7 +1578,7 @@ namespace Microsoft.Xna.Framework.Graphics
             height = mode.Height;
         }
 #endif
-        
+
 
     }
 }

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -365,12 +365,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Create VAO
             // Indirect drawing does not work without VAO on some platforms (Android for instance)
-            // (for some reason this does not work for a scalar, works only for an array)
-            var a = new uint[1];
-            var dataPtr = GCHandle.Alloc(a, GCHandleType.Pinned);
-            var vao = (UIntPtr) dataPtr.AddrOfPinnedObject();
-            GL.GenVertexArrays(1, vao);
-            GL.BindVertexArray(a[0]);
+            // Check if function exist
+            if (GL.GenVertexArrays != null && GL.BindVertexArray != null) {
+                // (for some reason this does not work for a scalar, works only for an array)
+                var a = new uint[1];
+                var dataPtr = GCHandle.Alloc(a, GCHandleType.Pinned);
+                var vao = (UIntPtr) dataPtr.AddrOfPinnedObject();
+                GL.GenVertexArrays(1, vao);
+                GL.BindVertexArray(a[0]);
+            }
         }
 
         private DepthStencilState clearDepthStencilState = new DepthStencilState { StencilEnable = true };

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -1475,6 +1475,23 @@ namespace MonoGame.OpenGL
         internal delegate void MemoryBarrierDelegate(MemoryBarrierBits barriers);
         internal static MemoryBarrierDelegate MemoryBarrier;
 
+        /**********************************************************************************/
+
+        [System.Security.SuppressUnmanagedCodeSecurity()]
+        [UnmanagedFunctionPointer(callingConvention)]
+        [MonoNativeFunctionWrapper]
+        internal delegate void GenVertexArraysDelegate(int n, UIntPtr size);
+        internal static GenVertexArraysDelegate GenVertexArrays;
+
+        [System.Security.SuppressUnmanagedCodeSecurity()]
+        [UnmanagedFunctionPointer(callingConvention)]
+        [MonoNativeFunctionWrapper]
+        internal delegate void BindVertexArrayDelegate(UIntPtr vao);
+        internal static BindVertexArrayDelegate BindVertexArray;
+
+        /**********************************************************************************/
+
+
 #if DEBUG
         [UnmanagedFunctionPointer (CallingConvention.StdCall)]
         delegate void DebugMessageCallbackProc (int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam);
@@ -1644,6 +1661,9 @@ namespace MonoGame.OpenGL
             UnmapBuffer = LoadFunction<UnmapBufferDelegate> ("glUnmapBuffer");
             BufferSubData = LoadFunction<BufferSubDataDelegate> ("glBufferSubData");
             DeleteBuffers = LoadFunction<DeleteBuffersDelegate> ("glDeleteBuffers");
+
+            GenVertexArrays = LoadFunction<GenVertexArraysDelegate> ("glGenVertexArrays");
+            BindVertexArray = LoadFunction<BindVertexArrayDelegate> ("glBindVertexArray");
 
             VertexAttribPointer = LoadFunction<VertexAttribPointerDelegate> ("glVertexAttribPointer");
 

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -441,7 +441,7 @@ namespace MonoGame.OpenGL
         Rgba16f = 0x881A,
         R16f = 0x822D,
         Rg32f = 0x8230,
-        Rgba32f = 0x8814,    
+        Rgba32f = 0x8814,
         R8ui = 0x8232,
         R8i = 0x8231,
         R16ui = 0x8234,
@@ -506,9 +506,9 @@ namespace MonoGame.OpenGL
         Float = 0x1406,
         HalfFloat = 0x140B,
         HalfFloatOES = 0x8D61,
-        Byte = 0x1400,    
-        Short = 0x1402,  
-        Int = 0x1404,    
+        Byte = 0x1400,
+        Short = 0x1402,
+        Int = 0x1404,
         UnsignedShort = 0x1403,
         UnsignedInt = 0x1405,
         UnsignedInt1010102 = 0x8036,
@@ -607,6 +607,11 @@ namespace MonoGame.OpenGL
     {
         ShaderStorage = 0x00002000,
         All = 0xFFFFFFFF,
+    }
+
+    internal enum AccessFlags : uint
+    {
+        GlMapReadBit = 0x1,
     }
 
     internal partial class ColorFormat
@@ -1404,6 +1409,12 @@ namespace MonoGame.OpenGL
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [UnmanagedFunctionPointer(callingConvention)]
         [MonoNativeFunctionWrapper]
+        internal delegate IntPtr MapBufferRangeDelegate(BufferTarget target, IntPtr offset, IntPtr size, AccessFlags access);
+        internal static MapBufferRangeDelegate MapBufferRange;
+
+        [System.Security.SuppressUnmanagedCodeSecurity()]
+        [UnmanagedFunctionPointer(callingConvention)]
+        [MonoNativeFunctionWrapper]
         internal delegate void UnmapBufferDelegate(BufferTarget target);
         internal static UnmapBufferDelegate UnmapBuffer;
 
@@ -1543,10 +1554,10 @@ namespace MonoGame.OpenGL
             UniformMatrix4fv = LoadFunction<UniformMatrix4fvDelegate> ("glUniformMatrix4fv");
             UniformMatrix2x3fv = LoadFunction<UniformMatrix2x3fvDelegate> ("glUniformMatrix2x3fv");
             UniformMatrix2x4fv = LoadFunction<UniformMatrix2x4fvDelegate> ("glUniformMatrix2x4fv");
-            UniformMatrix3x2fv = LoadFunction<UniformMatrix3x2fvDelegate> ("glUniformMatrix3x2fv"); 
+            UniformMatrix3x2fv = LoadFunction<UniformMatrix3x2fvDelegate> ("glUniformMatrix3x2fv");
             UniformMatrix3x4fv = LoadFunction<UniformMatrix3x4fvDelegate> ("glUniformMatrix3x4fv");
             UniformMatrix4x2fv = LoadFunction<UniformMatrix4x2fvDelegate> ("glUniformMatrix4x2fv");
-            UniformMatrix4x3fv = LoadFunction<UniformMatrix4x3fvDelegate> ("glUniformMatrix4x3fv");        
+            UniformMatrix4x3fv = LoadFunction<UniformMatrix4x3fvDelegate> ("glUniformMatrix4x3fv");
 
             ReadPixelsInternal = LoadFunction<ReadPixelsDelegate> ("glReadPixels");
 
@@ -1629,6 +1640,7 @@ namespace MonoGame.OpenGL
             GenBuffers = LoadFunction<GenBuffersDelegate> ("glGenBuffers");
             BufferData = LoadFunction<BufferDataDelegate> ("glBufferData");
             MapBuffer = LoadFunction<MapBufferDelegate> ("glMapBuffer");
+            MapBufferRange = LoadFunction<MapBufferRangeDelegate> ("glMapBufferRange");
             UnmapBuffer = LoadFunction<UnmapBufferDelegate> ("glUnmapBuffer");
             BufferSubData = LoadFunction<BufferSubDataDelegate> ("glBufferSubData");
             DeleteBuffers = LoadFunction<DeleteBuffersDelegate> ("glDeleteBuffers");
@@ -1701,7 +1713,7 @@ namespace MonoGame.OpenGL
                 GL.LoadFrameBufferObjectEXTEntryPoints();
             }
             if (GL.RenderbufferStorageMultisample == null)
-            {                
+            {
                 if (Extensions.Contains("GL_APPLE_framebuffer_multisample"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleAPPLE");


### PR DESCRIPTION
There is no glMapBuffer() on GLES but it has the glMapBufferRange() as a more modern way to do the same. 
So I replaced the function and it is working. I've tested it on Windows 11 desktop and on Android phone with GLES 3.2